### PR TITLE
PP-7887: Abbreviations for Canary resource names

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ make-card-payment-worldpay-with-3ds | test | card_wpay_3ds_test |
 make-card-payment-worldpay-with-3ds2 | test | card_wpay_3ds2_test |
 make-card-payment-worldpay-with-3ds2-exemption | test | card_wpay_3ds2ex_test |
 make-card-payment-worldpay-without-3ds | test | card_wpay_test |
+cancel-card-payment-sandbox-without-3ds | test | cancel_sandbox_test |
+use-payment-link-for-sandbox | test | pymntlnk_sandbox_test |
 make-card-payment-epdq-with-3ds | staging | card_epdq_3ds_stag |
 make-card-payment-epdq-with-3ds2 | staging | card_epdq_3ds2_stag |
 make-card-payment-epdq-without-3ds | staging | card_epdq_stag |
@@ -38,6 +40,8 @@ make-card-payment-worldpay-with-3ds | staging | card_wpay_3ds_stag |
 make-card-payment-worldpay-with-3ds2 | staging | card_wpay_3ds2_stag |
 make-card-payment-worldpay-with-3ds2-exemption | staging | card_wpay_3ds2ex_stag |
 make-card-payment-worldpay-without-3ds | staging | card_wpay_stag |
+cancel-card-payment-sandbox-without-3ds | staging | cancel_sandbox_stag |
+use-payment-link-for-sandbox | staging | pymntlnk_sandbox_stag |
 make-card-payment-epdq-with-3ds | production | card_epdq_3ds_prod |
 make-card-payment-epdq-with-3ds2 | production | card_epdq_3ds2_prod |
 make-card-payment-epdq-without-3ds | production | card_epdq_prod |
@@ -49,6 +53,8 @@ make-card-payment-worldpay-with-3ds | production | card_wpay_3ds_prod |
 make-card-payment-worldpay-with-3ds2 | production | card_wpay_3ds2_prod |
 make-card-payment-worldpay-with-3ds2-exemption | production | card_wpay_3ds2ex_prod |
 make-card-payment-worldpay-without-3ds | production | card_wpay_prod |
+cancel-card-payment-sandbox-without-3ds | production | cancel_sandbox_prod |
+use-payment-link-for-sandbox | production | pymntlnk_sandbox_prod |
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,47 @@ They are managed via Terraform in which is stored in [pay-infra](https://github.
 
 The scripts which run the Canaries post application deploy can be found in [pay-ci](https://github.com/alphagov/pay-ci).
 
+## Naming
+
+The AWS Canary resources have a 21-character name limit. The full test name is included
+in the resource tags, however here's a quick reference guide:
+
+Scenario | Environment | Canary name
+------------ | ------------- | ------------- |
+make-card-payment-epdq-with-3ds | test | card_epdq_3ds_test |
+make-card-payment-epdq-with-3ds2 | test | card_epdq_3ds2_test |
+make-card-payment-epdq-without-3ds | test | card_epdq_test |
+make-card-payment-sandbox-without-3ds | test | card_sandbox_test |
+make-card-payment-smartpay-without-3ds | test | card_smartpay_test |
+make-card-payment-stripe-with-3ds2 | test | card_stripe_3ds_test |
+make-card-payment-stripe-without-3ds | test | card_stripe_test |
+make-card-payment-worldpay-with-3ds | test | card_wpay_3ds_test |
+make-card-payment-worldpay-with-3ds2 | test | card_wpay_3ds2_test |
+make-card-payment-worldpay-with-3ds2-exemption | test | card_wpay_3ds2ex_test |
+make-card-payment-worldpay-without-3ds | test | card_wpay_test |
+make-card-payment-epdq-with-3ds | staging | card_epdq_3ds_stag |
+make-card-payment-epdq-with-3ds2 | staging | card_epdq_3ds2_stag |
+make-card-payment-epdq-without-3ds | staging | card_epdq_stag |
+make-card-payment-sandbox-without-3ds | staging | card_sandbox_stag |
+make-card-payment-smartpay-without-3ds | staging | card_smartpay_stag |
+make-card-payment-stripe-with-3ds2 | staging | card_stripe_3ds_stag |
+make-card-payment-stripe-without-3ds | staging | card_stripe_stag |
+make-card-payment-worldpay-with-3ds | staging | card_wpay_3ds_stag |
+make-card-payment-worldpay-with-3ds2 | staging | card_wpay_3ds2_stag |
+make-card-payment-worldpay-with-3ds2-exemption | staging | card_wpay_3ds2ex_stag |
+make-card-payment-worldpay-without-3ds | staging | card_wpay_stag |
+make-card-payment-epdq-with-3ds | production | card_epdq_3ds_prod |
+make-card-payment-epdq-with-3ds2 | production | card_epdq_3ds2_prod |
+make-card-payment-epdq-without-3ds | production | card_epdq_prod |
+make-card-payment-sandbox-without-3ds | production | card_sandbox_prod |
+make-card-payment-smartpay-without-3ds | production | card_smartpay_prod |
+make-card-payment-stripe-with-3ds2 | production | card_stripe_3ds_prod |
+make-card-payment-stripe-without-3ds | production | card_stripe_prod |
+make-card-payment-worldpay-with-3ds | production | card_wpay_3ds_prod |
+make-card-payment-worldpay-with-3ds2 | production | card_wpay_3ds2_prod |
+make-card-payment-worldpay-with-3ds2-exemption | production | card_wpay_3ds2ex_prod |
+make-card-payment-worldpay-without-3ds | production | card_wpay_prod |
+
 ## Structure
 
 ### Stubs


### PR DESCRIPTION
There is a 21-character limit on Canary resource names, so let's add a handy guide to the README.

The worldpay 3ds2 exemption tests are *juuuust* squeezed into 21 characters!