### PR TITLE
PP-7887: Increase timeout for page.waitForNavigation

### DIFF
--- a/helpers/smokeTestHelpers.js
+++ b/helpers/smokeTestHelpers.js
@@ -109,14 +109,14 @@ async function enterCardDetailsAndSubmit (page, cardDetails, emailAddress) {
     await page.click('.charge-new__content > #card-details-wrap > #card-details #submit-card-details')
   })
 
-  await page.waitForNavigation()
+  await page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 60000 })
 }
 
 async function enterCardDetailsAndConfirm (nextUrl, cardDetails, emailAddress) {
   log.info(`Going to get page ${nextUrl}`)
   const page = await synthetics.getPage()
 
-  const navigationPromise = page.waitForNavigation()
+  const navigationPromise = page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 60000 })
 
   await synthetics.executeStep('Goto_0', async function () {
     await page.goto(nextUrl, { waitUntil: 'domcontentloaded', timeout: 60000 })
@@ -138,7 +138,7 @@ async function enterCardDetailsContinue3dsAndConfirm (nextUrl, cardDetails, emai
   log.info(`Going to get page ${nextUrl}`)
   const page = await synthetics.getPage()
 
-  const navigationPromise = page.waitForNavigation()
+  const navigationPromise = page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 60000 })
 
   await synthetics.executeStep('Goto_0', async function () {
     await page.goto(nextUrl, { waitUntil: 'domcontentloaded', timeout: 60000 })


### PR DESCRIPTION
Our Canaries are intermittently timing out on the `page.waitForNavigation` commands. Increase the timeout from 30s to 60s for now, and use `waitUntil: domcontentloaded` to hopefully speed this up (i.e. don't wait for images/frames to be loaded). We use this pattern already in the `page.goto` commands ([example here](https://github.com/alphagov/pay-smoke-tests/blob/main/helpers/smokeTestHelpers.js#L122)).

See https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-pagewaitfornavigationoptions for details on the options.
