### PR TITLE
PP-7887: Remove waitForNavigation step from enterCardDetailsAndSubmit helper

### DIFF
--- a/helpers/smokeTestHelpers.js
+++ b/helpers/smokeTestHelpers.js
@@ -106,8 +106,6 @@ async function enterCardDetailsAndSubmit (page, cardDetails, emailAddress) {
     await page.waitForSelector('.charge-new__content > #card-details-wrap > #card-details #submit-card-details')
     await page.click('.charge-new__content > #card-details-wrap > #card-details #submit-card-details')
   })
-
-  await page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 60000 })
 }
 
 async function enterCardDetailsAndConfirm (nextUrl, cardDetails, emailAddress) {


### PR DESCRIPTION
This step in the helper function was causing the smoke tests that use it to intermittently timeout.

We've tested removing this line on the following canaries and they've passed (where they previously were failing more often than not):
- `card_wpay_3ds_test`
- `card_sandbox_test`
- `card_wpay_test`