### PR TITLE
[PP-7873] Potential Actions Cache Key Fix

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -26,8 +26,6 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: Install Node Modules
         run: npm install
       - name: Cache Working Directory
@@ -36,7 +34,7 @@ jobs:
           cache-name: cache-working-dir
         with:
           path: "*"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('*')}}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
   test:
     needs: prepare
     name: Test Build
@@ -48,9 +46,7 @@ jobs:
           cache-name: cache-working-dir
         with:
           path: "*"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('*')}}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
       - name: Node Lint
         run: npm run lint
       - name: NPM Build
@@ -61,7 +57,7 @@ jobs:
           cache-name: cache-build-dist
         with:
           path: dist
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('webpack.config.js', 'dist/**')}}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
   package:
     needs: test
     name: Package
@@ -73,9 +69,7 @@ jobs:
           cache-name: cache-build-dist
         with:
           path: dist
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('webpack.config.js', 'dist/**')}}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
       - name: Get Next Version Number
         id: next-version
         uses: actions/github-script@v3.1.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
           cache-name: cache-working-dir
         with:
           path: "*"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('*')}}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
   build:
     needs: prepare
     name: Build
@@ -50,9 +50,7 @@ jobs:
           cache-name: cache-working-dir
         with:
           path: "*"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('*')}}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
       - name: Debug LS
         run: |
           pwd
@@ -67,7 +65,7 @@ jobs:
           cache-name: cache-build-dist
         with:
           path: dist
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('webpack.config.js', 'dist/**')}}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
   release:
     needs: build
     name: Release
@@ -79,9 +77,7 @@ jobs:
           cache-name: cache-build-dist
         with:
           path: dist
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('webpack.config.js', 'dist/**')}}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
       - name: Get Next Version Number
         id: next-version
         uses: actions/github-script@v3.1.0


### PR DESCRIPTION
## What?
This changes the cache keys used by the caching steps between multiple Jobs of a Github Actions workflow. By making these changes, we should reduce the chance that stale assets could be reused for a subsequent run.

N.B. The changes to the PR pipeline are likely not going to take effect until this PR is merged into main.