### PR TITLE
[PP-7873] Another cache key fix using the `github` context.

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -34,7 +34,7 @@ jobs:
           cache-name: cache-working-dir
         with:
           path: "*"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
   test:
     needs: prepare
     name: Test Build
@@ -46,7 +46,7 @@ jobs:
           cache-name: cache-working-dir
         with:
           path: "*"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
       - name: Node Lint
         run: npm run lint
       - name: NPM Build
@@ -57,7 +57,7 @@ jobs:
           cache-name: cache-build-dist
         with:
           path: dist
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
   package:
     needs: test
     name: Package
@@ -69,7 +69,7 @@ jobs:
           cache-name: cache-build-dist
         with:
           path: dist
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
       - name: Get Next Version Number
         id: next-version
         uses: actions/github-script@v3.1.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
           cache-name: cache-working-dir
         with:
           path: "*"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
   build:
     needs: prepare
     name: Build
@@ -50,7 +50,7 @@ jobs:
           cache-name: cache-working-dir
         with:
           path: "*"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
       - name: Debug LS
         run: |
           pwd
@@ -65,7 +65,7 @@ jobs:
           cache-name: cache-build-dist
         with:
           path: dist
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
   release:
     needs: build
     name: Release
@@ -77,7 +77,7 @@ jobs:
           cache-name: cache-build-dist
         with:
           path: dist
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.GITHUB_SHA }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
       - name: Get Next Version Number
         id: next-version
         uses: actions/github-script@v3.1.0


### PR DESCRIPTION
## What?
So it looks like the previous environment variable didn't exist in the context of our caching action, so I have switched all the `GITHUB_SHA` environment variables to use the `github.sha` context variable instead.

Again, the change from this will likely not be visible until merged into main.