### PR TITLE
PP-7887 Fix flakiness of payment link test

### DIFF
--- a/run-local/index.js
+++ b/run-local/index.js
@@ -46,8 +46,13 @@ if (!argv.test || !tests[argv.test]) {
 
 async function runTest (testName) {
   console.log(`Running ${testName}`)
+  try{
   await tests[testName].handler()
-  process.exit(0)
+    process.exit(0)
+  } catch(err){
+    console.log(`Failed to run test: ${err.message}`)
+    process.exit(1)
+  }
 }
 
 runTest(argv.test)

--- a/use-payment-link-for-sandbox/index.js
+++ b/use-payment-link-for-sandbox/index.js
@@ -17,10 +17,10 @@ async function clickProceedToPaymentButton (page) {
   log.info('Click on "Proceed to payment" button')
   await synthetics.executeStep('Click on "Proceed to payment" button', async function () {
     await page.waitForSelector('#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > .push-bottom > .govuk-button')
+    const navigationPromise = page.waitForNavigation()
     await page.click('#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > .push-bottom > .govuk-button')
+    await navigationPromise
   })
-
-  await page.waitForNavigation()
 }
 
 async function navigateToPayStart (page, paymentLinkUrl) {


### PR DESCRIPTION
The `waitForNavigation()` function returns a promise which resolves the
next time the page navigates to a new URL or reloads. As per the
puppeteer docs the promise should be obtained before the action to
change pages or reload, and then `await` for the promise to revolve to
signal that the action has completed.

Previously the test was obtaining and waiting for the promise to resolve
after it had performed the page action. This meant on ocassion the page
had already completed the navigation before `waitForNavigation()` was
invoked and the promise obtained, and the test would timeout waiting for
the navigation to complete after it had already done so.

Link to the puppeteer docs:
https://github.com/puppeteer/puppeteer/blob/v1.7.0/docs/api.md#pagewaitfornavigationoptions

## What?
[As per the puppeteer docs the `waitForNavigation`](https://github.com/puppeteer/puppeteer/blob/v1.7.0/docs/api.md#pagewaitfornavigationoptions) should be used in this pattern:
```
const navigationPromise = page.waitForNavigation();
await page.click('a.my-link'); // Clicking the link will indirectly cause a navigation
await navigationPromise; // The navigationPromise resolves after navigation has finished
```


## Testing
Confirmed that when the test times out it is already on the enter card details page by capturing screen shot from local failed runs.

Using the following bit of bash I ran the payment link test 50 times, before and after the fix is applied
```
for i in {1..50}; do echo "run: $i -> $( if runPaymentLinkTest > /dev/null 2>&1; then echo "passed"; else echo "failed"; fi)" ; done
```
where 
```
runPaymentLinkTest is aliased to `aws-vault exec deploy -- node run-local/index.js --test use-payment-link-for-sandbox  --env test'
```

Prior to the change 10 out of 50 runs failed. With this change all 50 passed.
