### PR TITLE
PP-8387 Add notifications smoke test

### DIFF
--- a/notifications-sandbox/index.js
+++ b/notifications-sandbox/index.js
@@ -1,0 +1,34 @@
+const { ENVIRONMENT } = process.env
+const https = require('https')
+
+const log = require('SyntheticsLogger')
+const smokeTestHelpers = require('../helpers/smokeTestHelpers')
+
+exports.handler = async () => {
+  const secret = await smokeTestHelpers.getSecret(`${ENVIRONMENT}/smoke_test`)
+  const apiToken = secret.NOTIFICATIONS_SANDBOX_AUTH_TOKEN
+  const notificationsHostName = secret.NOTIFICATIONS_SANDBOX_HOST
+  const path = '/v1/api/notifications/sandbox'
+
+  log.info(`Sending POST request to ${notificationsHostName}${path}`)
+  const options = {
+    host: notificationsHostName,
+    port: 443,
+    headers: {
+      Authorization: apiToken
+    },
+    path,
+    method: 'POST'
+  }
+
+  return new Promise((resolve, reject) => {
+    https.request(options, res => {
+      if (res.statusCode === 200) {
+        log.info('Notifications responded with 200 OK')
+        resolve()
+      } else {
+        reject(new Error(`Notifications endpoint responded with ${res.statusCode} status`))
+      }
+    }).end()
+  })
+}

--- a/run-local/index.js
+++ b/run-local/index.js
@@ -36,7 +36,8 @@ const tests = {
   'make-card-payment-worldpay-with-3ds2-exemp': proxyquire('../make-card-payment-worldpay-with-3ds2-exemption-engine', stubs),
   'make-card-payment-worldpay-without-3ds': proxyquire('../make-card-payment-worldpay-without-3ds', stubs),
   'cancel-card-payment-sandbox-without-3ds': proxyquire('../cancel-card-payment-sandbox-without-3ds', stubs),
-  'use-payment-link-for-sandbox': proxyquire('../use-payment-link-for-sandbox', stubs)
+  'use-payment-link-for-sandbox': proxyquire('../use-payment-link-for-sandbox', stubs),
+  'notifications-sandbox': proxyquire('../notifications-sandbox', stubs)
 }
 
 if (!argv.test || !tests[argv.test]) {
@@ -50,7 +51,7 @@ async function runTest (testName) {
     await tests[testName].handler()
     process.exit(0)
   } catch (err) {
-    console.log(`Failed to run test: ${err.message}`)
+    console.log(`test failed: ${err.message}`)
     process.exit(1)
   }
 }


### PR DESCRIPTION
Simply makes a POST request to the sandbox notifications endpoint and
expects to receive a HTTP 200 response code. Updated the run-local
script to include this test.

## What?
See it running locally (secrets added for test env only so far)
```
gds5062-2:pay-smoke-tests danworth$ aws-vault exec deploy -- node run-local/index.js --test notifications-sandbox --env test
Running notifications-sandbox
Sending POST request to notifications-test-12.test.pymnt.uk/v1/api/notifications/sandbox
Notifications responded with 200 OK
```
Running the test with an invalid API token yeilds
```
gds5062-2:pay-smoke-tests danworth$ aws-vault exec deploy -- node run-local/index.js --test notifications-sandbox --env test
Running notifications-sandbox
Sending POST request to notifications-test-12.test.pymnt.uk/v1/api/notifications/sandbox
test failed: Notifications endpoint responded with 403 status
```