### PR TITLE
PP-8387 Correct the if condition for creating a release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,7 +122,7 @@ jobs:
           path: ${{ steps.create-zip.outputs.ZIPFILENAME }}.zip
           if-no-files-found: error
       - name: Create Release
-        if: ${{ steps.branch-name.outputs.BRANCH == 'main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         id: create-release
         uses: actions/github-script@v3.1.0
         with:


### PR DESCRIPTION
Fix copy and paste error. Replace with a simple means of checking the
branch name using basic Github Actions syntax.

## What?
Whops, copied from another workflow file in pay-dockerfiles but this file does not have the step it relies upon. Github docs showing example: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#determining-when-to-use-contexts
