### PR TITLE
PP-8512 Fix Stripe 3ds2 tests

### DIFF
--- a/make-card-payment-stripe-with-3ds2/index.js
+++ b/make-card-payment-stripe-with-3ds2/index.js
@@ -30,8 +30,18 @@ const enterCardDetailsContinueStripe3dsAndConfirm = async function (nextUrl, car
     await page.waitForSelector('#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > .iframe-3ds')
   })
 
-  // Need to find a way to do the following method
-  // wait.until(ExpectedConditions.javaScriptThrowsNoExceptions("window.frames[0].frames[0].postMessage({test_source: {authorize: true}}, '*')"));
+  await synthetics.executeStep('Click submit button on 3DS page', async function () {
+    await page.waitForSelector('iframe.iframe-3ds')
+
+    const firstElementHandle = await page.$('iframe.iframe-3ds')
+    const firstIframe = await firstElementHandle.contentFrame()
+    await firstIframe.waitForSelector('iframe.FullscreenFrame')
+
+    const secondElementHandle = await firstIframe.$('iframe.FullscreenFrame')
+    const secondIframe = await secondElementHandle.contentFrame()
+    await secondIframe.waitForSelector('button#test-source-authorize-3ds')
+    await secondIframe.click('button#test-source-authorize-3ds')
+  })
 
   await navigationPromise
 
@@ -52,7 +62,6 @@ exports.handler = async () => {
   log.info(`Going to create a payment to ${provider}`)
   const createPaymentRequest = smokeTestHelpers.createPaymentRequest(provider, '3ds2')
   const createPaymentResponse = await smokeTestHelpers.createPayment(apiToken, publicApiUrl, createPaymentRequest)
-  log.info(createPaymentResponse)
 
   await enterCardDetailsContinueStripe3dsAndConfirm(createPaymentResponse._links.next_url.href, stripe3dsCard, secret.EMAIL_ADDRESS)
   log.info('Finished entering card details and confirmed')

--- a/stubs/syntheticsStub/index.js
+++ b/stubs/syntheticsStub/index.js
@@ -3,7 +3,10 @@ const puppeteer = require('puppeteer')
 exports.getPage = async () => {
   let page
   const browser = await puppeteer.launch({
-    headless: true,
+    headless: false,
+    args: [
+      '--disable-features=IsolateOrigins,site-per-process'
+    ],
     defaultViewport: {
       width: 1024,
       height: 768


### PR DESCRIPTION
Update the Stripe 3DS2 tests to correctly complete the 3DS challenge
Iframe.

Change the puppeteer stubs which are used for local running so they run
in headed mode which is more useful when running locally.

## What?
Stripe 3DS seems a bit more complicated than Worldpay because its an iframe in an iframe. I've run these tests for test, staging and production locally and they pass.

The following change to the puppeteer stub is necessary when running in headed mode in order to get the iframes.
```
args: [
      '--disable-features=IsolateOrigins,site-per-process'
    ],
```

```
gds5062-2:pay-smoke-tests danworth$ aws-vault exec deploy -- node run-local/index.js --env production --test make-card-payment-stripe-with-3ds2
Running make-card-payment-stripe-with-3ds2
Going to create a payment to stripe
Going to get page https://www.payments.service.gov.uk/secure/4f8f5aa6-22a9-46b6-bf1a-a8aa3f1b5a61
Finished entering card details and confirmed
Payment status is success
```