### PR TITLE
PP-8512 Add the option to run the tests locally in headless mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ To run the tests locally use the `run-local/index.js` script. Provide the name
 of the test you want to run with the `--test` flag. It will print out the valid
 test names if none is provided or an invalid name is given. Provide the environment to run the tests for with the '--env' flag.
 
+To run the tests in a headless mode use the `--headless` flag.
+
 Example:
 
-> aws-vault exec deploy -- node run-local/index.js --test make-card-payment-sandbox-without-3ds --env test
+> aws-vault exec deploy -- node run-local/index.js --test make-card-payment-sandbox-without-3ds --env test --headless
 
 
 ### Tests

--- a/stubs/syntheticsStub/index.js
+++ b/stubs/syntheticsStub/index.js
@@ -1,28 +1,31 @@
 const puppeteer = require('puppeteer')
 
-exports.getPage = async () => {
-  let page
-  const browser = await puppeteer.launch({
-    headless: false,
-    args: [
-      '--disable-features=IsolateOrigins,site-per-process'
-    ],
-    defaultViewport: {
-      width: 1024,
-      height: 768
+module.exports = function init (headless = false) {
+  return {
+    getPage: async () => {
+      let page
+      const browser = await puppeteer.launch({
+        headless,
+        args: [
+          '--disable-features=IsolateOrigins,site-per-process'
+        ],
+        defaultViewport: {
+          width: 1024,
+          height: 768
+        }
+      })
+      const pages = await browser.pages()
+      if (pages.length <= 1) {
+        page = await browser.newPage()
+      }
+      return page
+    },
+    executeStep: async (step = null, stepFunc) => {
+      try {
+        await stepFunc()
+      } catch (e) {
+        console.error(e)
+      }
     }
-  })
-  const pages = await browser.pages()
-  if (pages.length <= 1) {
-    page = await browser.newPage()
-  }
-  return page
-}
-
-exports.executeStep = async (step = null, stepFunc) => {
-  try {
-    await stepFunc()
-  } catch (e) {
-    console.error(e)
   }
 }


### PR DESCRIPTION
Also add a help text to the command.

## What?
```
gds5062-2:pay-smoke-tests danworth$ aws-vault exec deploy -- node run-local/index.js --env production --test make-card-payment-stripe-with-3ds2 --headless
```
and 
```
gds5062-2:pay-smoke-tests danworth$ aws-vault exec deploy -- node run-local/index.js --env production --test make-card-payment-stripe-with-3ds2
```
help text/usage provided
```
gds5062-2:pay-smoke-tests danworth$ aws-vault exec deploy -- node run-local/index.js
Options:
  --env must be one of: test,staging,production
  --test must be one of:
   make-card-payment-sandbox-without-3ds,make-card-payment-smartpay-without-3ds,make-card-payment-stripe-with-3ds2,make-card-payment-stripe-without-3ds,make-card-payment-worldpay-with-3ds,make-card-payment-worldpay-with-3ds2,make-card-payment-worldpay-with-3ds2-exemp,make-card-payment-worldpay-without-3ds,cancel-card-payment-sandbox-without-3ds,use-payment-link-for-sandbox,notifications-sandbox
  [--headless] run browser in headless mode, default to false
```
