### PR TITLE
[PP-8910] Populate POST to Notifications Sandbox

### DIFF
--- a/notifications-sandbox/index.js
+++ b/notifications-sandbox/index.js
@@ -11,23 +11,21 @@ exports.handler = async () => {
   const path = '/v1/api/notifications/sandbox'
 
   log.info(`Sending POST request to ${notificationsHostName}${path}`)
-  
+
   const data = JSON.stringify({
-    body: "sandbox-notifications"
+    body: 'sandbox-notifications'
   })
 
   const options = {
     host: notificationsHostName,
     port: 443,
     headers: {
-      Authorization: apiToken
-    },
-    path,
-    method: 'POST',
-    headers: {
+      Authorization: apiToken,
       'Content-Type': 'application/json',
       'Content-Length': data.length
-    }
+    },
+    path,
+    method: 'POST'
   }
 
   return new Promise((resolve, reject) => {

--- a/notifications-sandbox/index.js
+++ b/notifications-sandbox/index.js
@@ -11,6 +11,11 @@ exports.handler = async () => {
   const path = '/v1/api/notifications/sandbox'
 
   log.info(`Sending POST request to ${notificationsHostName}${path}`)
+  
+  const data = JSON.stringify({
+    body: "sandbox-notifications"
+  })
+
   const options = {
     host: notificationsHostName,
     port: 443,
@@ -18,7 +23,11 @@ exports.handler = async () => {
       Authorization: apiToken
     },
     path,
-    method: 'POST'
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': data.length
+    }
   }
 
   return new Promise((resolve, reject) => {
@@ -29,6 +38,6 @@ exports.handler = async () => {
       } else {
         reject(new Error(`Notifications endpoint responded with ${res.statusCode} status`))
       }
-    }).end()
+    }).write(data).end()
   })
 }


### PR DESCRIPTION
## What?
This update to the Sandbox Notification Smoke Test sends a non-empty body along with our POST request to `/v1/api/notifications/sandbox` so as not to get trapped by NAXSI Rule 16, "Empty POST".