### PR TITLE
PP-8910 Fix Notifications Sandbox test

### DIFF
--- a/notifications-sandbox/index.js
+++ b/notifications-sandbox/index.js
@@ -29,13 +29,16 @@ exports.handler = async () => {
   }
 
   return new Promise((resolve, reject) => {
-    https.request(options, res => {
+    const request = https.request(options, res => {
       if (res.statusCode === 200) {
         log.info('Notifications responded with 200 OK')
         resolve()
       } else {
         reject(new Error(`Notifications endpoint responded with ${res.statusCode} status`))
       }
-    }).write(data).end()
+    })
+
+    request.write(data)
+    request.end()
   })
 }


### PR DESCRIPTION
As it was it errors with:
```
Running notifications-sandbox
Sending POST request to
notifications-test-12.test.pymnt.uk/v1/api/notifications/sandbox
test failed: https.request(...).write(...).end is not a function
```

This fixes it so it runs correctly:
```
Sending POST request to
notifications-test-12.test.pymnt.uk/v1/api/notifications/sandbox
Notifications responded with 200 OK
```

## What?
Run the test locally (against the env of your choice and using the same secrets from deploy account) with the following (instructions in [README](https://github.com/alphagov/pay-smoke-tests/blob/main/README.md#test-harness)). This was run against test-12 with release 51 of notifications (which has the updated naxsi rules).
```
gds5062-2:run-local danworth$ aws-vault exec deploy -- node index.js --env test --test notifications-sandbox --headless
Running notifications-sandbox
Sending POST request to notifications-test-12.test.pymnt.uk/v1/api/notifications/sandbox
Notifications responded with 200 OK
```
### NOTE
We should consider running all of the smoke tests using the local test harness as part of [CI workflow](https://github.com/alphagov/pay-smoke-tests/blob/main/.github/workflows/build.yaml) see ([PP-8999](https://payments-platform.atlassian.net/browse/PP-8999))