### PR TITLE
PP-9216: Fix GHA workflow permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,6 +62,8 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
   release:
     needs: build
+    permissions:
+      contents: write
     name: Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Following changes to alphagov default settings. The GHA workflow needs `contents:write` permissions to create a release.

See https://github.com/alphagov/pay-nginx-forward-proxy/pull/22 for the equivalent change in nginx-forward-proxy.