### PR TITLE
PP-9308: Try github-script v6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
       - name: Get Next Version Number
         id: next-version
-        uses: actions/github-script@441359b1a30438de65712c2fbca0abe4816fa667
+        uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -126,7 +126,7 @@ jobs:
       - name: Create Release
         if: ${{ github.ref == 'refs/heads/main' }}
         id: create-release
-        uses: actions/github-script@441359b1a30438de65712c2fbca0abe4816fa667
+        uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,13 +76,13 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
       - name: Get Next Version Number
         id: next-version
-        uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3
+        uses: actions/github-script@441359b1a30438de65712c2fbca0abe4816fa667
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             var currentReleaseName = ""
             try {
-              const getReleaseResp = await github.repos.getLatestRelease({
+              const getReleaseResp = await github.rest.repos.getLatestRelease({
                 owner: context.repo.owner,
                 repo: context.repo.repo
               })
@@ -126,13 +126,13 @@ jobs:
       - name: Create Release
         if: ${{ github.ref == 'refs/heads/main' }}
         id: create-release
-        uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3
+        uses: actions/github-script@441359b1a30438de65712c2fbca0abe4816fa667
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             var fs = require('fs')
             try {
-              const releaseResponse = await github.repos.createRelease({
+              const releaseResponse = await github.rest.repos.createRelease({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 tag_name: "${{ steps.next-version.outputs.NEXTVERSION }}",
@@ -141,7 +141,7 @@ jobs:
 
               const fileName = "${{ steps.create-zip.outputs.ZIPFILENAME }}.zip"
 
-              const releaseUploadResponse = await github.repos.uploadReleaseAsset({
+              const releaseUploadResponse = await github.rest.repos.uploadReleaseAsset({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 release_id: releaseResponse.data.id,


### PR DESCRIPTION
Involves breaking changes to the github context object (see [changelog](https://github.com/actions/github-script/releases)).

This looks to have worked for v6 as well as v5, so I'll squash the commits on merge.

The SHA pin has been added to the repo settings.