### PR TITLE
BAU: Exclude Github Actions/Dependabot from post-merge worklow

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '.github/**'
 
 concurrency: smoke-tests-post-merge
 


### PR DESCRIPTION
See ADR https://github.com/alphagov/pay-architecture/pull/49/files
