### PR TITLE
PP-10675: replaced usage of set-output in post-merge.yml

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -69,7 +69,8 @@ jobs:
           ZIPFILENAME="pay-smoke-tests-${NEXTVERSION}"
           zip -j -r $ZIPFILENAME.zip dist/zip/*
 
-          echo "::set-output name=ZIPFILENAME::${ZIPFILENAME}"
+          echo "ZIPFILENAME=${ZIPFILENAME}" >> $GITHUB_OUTPUT
+          
       - name: Upload Archive
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb
         with:


### PR DESCRIPTION

Located and replaced all usages of set-output commands in our workflows.