### PR TITLE
PP-10675: replaced usage of set-output in post-merge.yml

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -48,7 +48,7 @@ jobs:
 
               var nextRelease = "v" + (currentReleaseNumber + 1)
               console.log(`Next Release Version: ${nextRelease}`)
-              console.log(`::set-output name=NEXTVERSION::${nextRelease}`)
+              console.log("NEXTVERSION=${nextRelease}") >> $GITHUB_OUTPUT
             } catch(err) {
               if (err.name == 'HttpError') {
                 console.warn("Found HttpError")


### PR DESCRIPTION
Located and replaced all usages of set-output commands in our workflows.