### PR TITLE
BAU: Try a fix for post-merge release version output

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -48,7 +48,7 @@ jobs:
 
               var nextRelease = "v" + (currentReleaseNumber + 1)
               console.log(`Next Release Version: ${nextRelease}`)
-              console.log(`NEXTVERSION=${nextRelease} >> $GITHUB_OUTPUT`)
+              console.log(`echo NEXTVERSION=${nextRelease} >> $GITHUB_OUTPUT`)
             } catch(err) {
               if (err.name == 'HttpError') {
                 console.warn("Found HttpError")


### PR DESCRIPTION
## What?

Following an ordinary dependabot merge, the post-merge release workflow failed as the version number was not being correctly set to the GITHUB_OUTPUT env. I think this was because the statement was missing an `echo` but I'm not sure - let's try it out.
