### PR TITLE
BAU: Fix for NEXTVERSION output variable

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -48,7 +48,7 @@ jobs:
 
               var nextRelease = "v" + (currentReleaseNumber + 1)
               console.log(`Next Release Version: ${nextRelease}`)
-              console.log(`echo NEXTVERSION=${nextRelease} >> $GITHUB_OUTPUT`)
+              console.log(`echo "NEXTVERSION=${nextRelease}" >> $GITHUB_OUTPUT`)
             } catch(err) {
               if (err.name == 'HttpError') {
                 console.warn("Found HttpError")
@@ -63,10 +63,8 @@ jobs:
             }
       - name: Create .zip Archive
         id: create-zip
-        env:
-          NEXTVERSION: ${{ steps.next-version.outputs.NEXTVERSION }}
         run: |
-          ZIPFILENAME="pay-smoke-tests-${NEXTVERSION}"
+          ZIPFILENAME="pay-smoke-tests-${{ steps.next-version.outputs.NEXTVERSION }}"
           zip -j -r $ZIPFILENAME.zip dist/zip/*
 
           echo "ZIPFILENAME=${ZIPFILENAME}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
[The previous fix attempt](https://github.com/alphagov/pay-smoke-tests/pull/162) didn't work - see https://github.com/alphagov/pay-smoke-tests/actions/runs/4498791156/jobs/7915870308 for an example failure run. 

This fix adds quoting to the `echo` command (that's being run via a Node script). Also removes the unnecessary env var in the create-zip step (to rule out that causing the error).
