### PR TITLE
BAU: Parse latest release number with bash instead of node

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -27,40 +27,17 @@ jobs:
         with:
           path: dist
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
-      - name: Get Next Version Number
-        id: next-version
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var currentReleaseName = ""
-            try {
-              const getReleaseResp = await github.rest.repos.getLatestRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo
-              })
-              currentReleaseName = getReleaseResp.data.name
-              console.log(`Current Release Name: ${currentReleaseName}`)
-
-              var currentReleaseNumberStr = currentReleaseName.replace(/\D/g, '')
-              var currentReleaseNumberParseInt = parseInt(currentReleaseNumberStr)
-              var currentReleaseNumber = isNaN(currentReleaseNumberParseInt) ? 0 : currentReleaseNumberParseInt
-
-              var nextRelease = "v" + (currentReleaseNumber + 1)
-              console.log(`Next Release Version: ${nextRelease}`)
-              console.log(`echo "NEXTVERSION=${nextRelease}" >> $GITHUB_OUTPUT`)
-            } catch(err) {
-              if (err.name == 'HttpError') {
-                console.warn("Found HttpError")
-                if (err.status == 404)  {
-                  console.error("Error 404: No previous GitHub Releases found.")
-                  throw err
-                }
-              } else {
-                console.error(`Failed to get the latest release: ${err.message}`)
-                throw err
-              }
-            }
+      - name: Parse Version Number
+        id: next-version-number
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          LATEST_RELEASE_NUMBER=$(git describe --abbrev=0 --tags --match "v*" | cut -d "v" -f 2 || true)
+          number_regex='^[0-9]+$'
+          if ! [[ ${LATEST_RELEASE_NUMBER} =~ $number_regex ]]; then
+           LATEST_RELEASE_NUMBER=0
+          fi
+          NEW_RELEASE_NUMBER=$((LATEST_RELEASE_NUMBER + 1))
+          echo "NEXTVERSION=v${NEW_RELEASE_NUMBER}" >> $GITHUB_OUTPUT
       - name: Create .zip Archive
         id: create-zip
         run: |

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -28,7 +28,7 @@ jobs:
           path: dist
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
       - name: Parse Version Number
-        id: next-version-number
+        id: next-version
         run: |
           cd ${GITHUB_WORKSPACE}
           LATEST_RELEASE_NUMBER=$(git describe --abbrev=0 --tags --match "v*" | cut -d "v" -f 2 || true)


### PR DESCRIPTION
For some reason the current Get Next Version Number workflow step is not registering the NEXTVERSION env var in GITHUB_OUTPUT. [See the latest failed run](https://github.com/alphagov/pay-smoke-tests/actions/runs/4666575445/jobs/8261331491):

```
# Get Next Version Number
Current Release Name: v82
Next Release Version: v83
echo "NEXTVERSION=v83" >> $GITHUB_OUTPUT

# Create .zip archive
ZIPFILENAME="pay-smoke-tests-"
```

Instead, let's try using a similar parse method to that which we use for [carbon-relay release tagging](https://github.com/alphagov/pay-dockerfiles/blob/main/.github/workflows/carbon-relay-post-merge.yml#L56) - `git describe` and a bit of string manipulation.
