### PR TITLE
BAU: Include actions/checkout in post-merge workflow

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -20,6 +20,10 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        with:
+          fetch-depth: 0
       - name: Retrieve Build Assets
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         env:


### PR DESCRIPTION
Otherwise the 'git describe' command in the `Parse Version Number` step will not be able to find the git repo.

See previous run: https://github.com/alphagov/pay-smoke-tests/actions/runs/4734433221/jobs/8403373932