### PR TITLE
BAU: Increase the time waiting for webhooks to 6 seconds from 3

### DIFF
--- a/helpers/smokeTestHelpers.js
+++ b/helpers/smokeTestHelpers.js
@@ -258,8 +258,8 @@ const wait = ms => new Promise(resolve => {
 const retrieveWebhookObjectFromS3WithRetries = async (environment, resourceId) => {
   let totalTimeTaken = 0
 
-  // We're trying every 100ms for a max of 3 seconds
-  for (const retryDelay of new Array(30).fill(100)) {
+  // We're trying every 100ms for a max of 6 seconds
+  for (const retryDelay of new Array(60).fill(100)) {
     await wait(retryDelay)
 
     totalTimeTaken += retryDelay


### PR DESCRIPTION
## What?
It sometimes takes a bit longer than 3 seconds for webhooks to be received, given it's an asynchronous event driven architecture with multiple components between the event being sent, and the webhook being received, I don't think it's unreasonable to wait a little longer, especially if it reduces false failures of our smoke tests.