### PR TITLE
PP-10496 Smoke test for Stripe recurring card payment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ in the resource tags, however here's a quick reference guide:
 | make-card-payment-worldpay-with-3ds2           | test        | card_wpay_3ds2_test   |
 | make-card-payment-worldpay-with-3ds2-exemption | test        | card_wpay_3ds2ex_test |
 | make-card-payment-worldpay-without-3ds         | test        | card_wpay_test        |
+| make-recurring-card-payment-stripe             | test        | rec_card_stripe_test  |
 | notifications-sandbox                          | test        | notifications_test    |
 | cancel-card-payment-sandbox-without-3ds        | test        | cancel_sandbox_test   |
 | use-payment-link-for-sandbox                   | test        | pymntlnk_sandbox_test |
@@ -33,6 +34,7 @@ in the resource tags, however here's a quick reference guide:
 | make-card-payment-worldpay-with-3ds2           | staging     | card_wpay_3ds2_stag   |
 | make-card-payment-worldpay-with-3ds2-exemption | staging     | card_wpay_3ds2ex_stag |
 | make-card-payment-worldpay-without-3ds         | staging     | card_wpay_stag        |
+| make-recurring-card-payment-stripe             | staging     | rec_card_stripe_stag  |
 | notifications-sandbox                          | staging     | notifications_stag    |
 | cancel-card-payment-sandbox-without-3ds        | staging     | cancel_sandbox_stag   |
 | use-payment-link-for-sandbox                   | staging     | pymntlnk_sandbox_stag |
@@ -43,6 +45,7 @@ in the resource tags, however here's a quick reference guide:
 | make-card-payment-worldpay-with-3ds2           | production  | card_wpay_3ds2_prod   |
 | make-card-payment-worldpay-with-3ds2-exemption | production  | card_wpay_3ds2ex_prod |
 | make-card-payment-worldpay-without-3ds         | production  | card_wpay_prod        |
+| make-recurring-card-payment-stripe             | production  | rec_card_stripe_prod  |
 | notifications-sandbox                          | production  | notifications_prod    |
 | cancel-card-payment-sandbox-without-3ds        | production  | cancel_sandbox_prod   |
 | use-payment-link-for-sandbox                   | production  | pymntlnk_sandbox_prod |

--- a/helpers/agreement-test-helpers.js
+++ b/helpers/agreement-test-helpers.js
@@ -1,0 +1,73 @@
+const https = require('https')
+
+async function createAgreement (apiToken, publicApiUrl, createAgreementPayload) {
+  const options = {
+    host: publicApiUrl,
+    port: 443,
+    headers: headers(apiToken),
+    path: '/v1/agreements',
+    method: 'POST'
+  }
+
+  return new Promise(resolve => {
+    https.request(options, res => {
+      if (res.statusCode !== 201) {
+        throw new Error(`publicapi responded with ${res.statusCode} status`)
+      }
+
+      let data = ''
+
+      res.on('data', d => data += d) // eslint-disable-line
+      res.on('end', () => resolve(JSON.parse(data)))
+      res.on('error', error => { throw new Error(error) })
+    }).end(JSON.stringify(createAgreementPayload))
+  })
+}
+
+function getCreateAgreementPayload (provider) {
+  return {
+    reference: generateAgreementReference(provider, 'agreement'),
+    description: 'should create agreement, setup agreement and take a recurring payment'
+  }
+}
+
+const generateAgreementReference = (provider, testDescription) => {
+  const reference = ['smoke_test', provider, testDescription, Math.floor(Math.random() * 100000)]
+  return reference.join('_')
+}
+
+async function getAgreement (apiToken, publicApiUrl, agreementId) {
+  const options = {
+    host: publicApiUrl,
+    port: 443,
+    headers: headers(apiToken),
+    path: `/v1/agreements/${agreementId}`,
+    method: 'GET'
+  }
+
+  return new Promise(resolve => {
+    https.request(options, res => {
+      if (res.statusCode !== 200) {
+        throw new Error(`publicapi responded with ${res.statusCode} status`)
+      }
+      let data = ''
+
+      res.on('data', d => data += d) // eslint-disable-line
+      res.on('end', () => resolve(JSON.parse(data)))
+      res.on('error', error => { throw new Error(error) })
+    }).end()
+  })
+}
+
+function headers (apiToken) {
+  return {
+    Authorization: `Bearer ${apiToken}`,
+    'Content-Type': 'application/json'
+  }
+}
+
+module.exports = {
+  getCreateAgreementPayload,
+  createAgreement,
+  getAgreement
+}

--- a/helpers/smoke-test-helpers.js
+++ b/helpers/smoke-test-helpers.js
@@ -32,12 +32,29 @@ async function createPayment (apiToken, publicApiUrl, createPaymentRequest) {
   })
 }
 
-function createPaymentRequest (provider, typeOf3ds) {
-  return {
+function createPaymentRequest (provider, typeOf3ds, agreementId) {
+  const paymentMethod = agreementId? 'recurring_card_payment': 'card_payment'
+  let payload = {
     amount: 100,
-    reference: generatePaymentReference(provider, typeOf3ds, 'card_payment'),
+    reference: generatePaymentReference(provider, typeOf3ds, paymentMethod),
     description: 'should create payment, enter card details and confirm',
     return_url: 'https://products.pymnt.uk/successful'
+  }
+
+  if (agreementId) {
+    payload.set_up_agreement = agreementId
+  }
+
+  return payload
+}
+
+function getCreateRecurringPaymentPayload (provider, agreementId) {
+  return {
+    amount: 100,
+    reference: generatePaymentReference(provider, '', 'recurring_card_payment'),
+    description: 'should create a recurring payment',
+    agreement_id: agreementId,
+    authorisation_mode: 'agreement'
   }
 }
 
@@ -302,6 +319,7 @@ module.exports = {
   enterCardDetailsAndConfirm,
   enterCardDetailsContinue3dsAndConfirm,
   generatePaymentReference,
+  getCreateRecurringPaymentPayload,
   getPayment,
   getSecret,
   headers,

--- a/make-recurring-card-payment-stripe/index.js
+++ b/make-recurring-card-payment-stripe/index.js
@@ -1,0 +1,95 @@
+const { ENVIRONMENT, WEBHOOKS_ENABLED } = process.env
+
+const log = require('SyntheticsLogger')
+const smokeTestHelpers = require('../helpers/smoke-test-helpers')
+const agreementTestHelpers = require('../helpers/agreement-test-helpers')
+
+const stripeCard = {
+  cardholderName: 'Test User',
+  cardNumber: '4242424242424242',
+  expiryMonth: smokeTestHelpers.expiryMonth,
+  expiryYear: smokeTestHelpers.expiryYear,
+  securityCode: '737'
+}
+const provider = 'stripe'
+let apiToken, publicApiUrl, secret
+
+async function createAgreement (provider) {
+  log.info(`Creating agreement for [${provider}]`)
+  const createAgreementPayload = agreementTestHelpers.getCreateAgreementPayload(provider)
+  const createAgreementResponse = await agreementTestHelpers.createAgreement(apiToken, publicApiUrl, createAgreementPayload)
+  log.info(`Created agreement [${createAgreementResponse.agreement_id}]`)
+
+  return createAgreementResponse
+}
+
+async function setupPaymentForAgreement (agreementId) {
+  log.info(`Setting up a payment for [${provider}] and agreement [${agreementId}]`)
+  let createPaymentRequest = smokeTestHelpers.createPaymentRequest(provider, 'non_3ds', agreementId)
+  let createPaymentResponse = await smokeTestHelpers.createPayment(apiToken, publicApiUrl, createPaymentRequest)
+  log.info(`Created payment [${createPaymentResponse.payment_id}] for agreement [${agreementId}]`)
+
+  await smokeTestHelpers.enterCardDetailsAndConfirm(createPaymentResponse._links.next_url.href, stripeCard, secret.EMAIL_ADDRESS)
+  log.info(`Finished setting up payment [${createPaymentResponse.payment_id}] for agreement [${agreementId}]`)
+
+  return assertPaymentStatus(createPaymentResponse.payment_id)
+}
+
+async function assertPaymentStatus (paymentId) {
+  let totalTimeTaken = 0
+
+  // query payment status every one second until it is processed asynchronously in connector for a maximum of 6 seconds
+  for (const retryDelay of new Array(6).fill(1000)) {
+    await wait(retryDelay)
+    totalTimeTaken += retryDelay
+
+    const payment = await smokeTestHelpers.getPayment(apiToken, publicApiUrl, paymentId)
+    const paymentStatus = payment.state.status
+    log.info(`Payment [${paymentId}] status is ${paymentStatus}`)
+
+    if (paymentStatus === 'success') {
+      return payment
+    }
+  }
+
+  throw new Error(`Payment [${paymentId}] status does not equal to success after multiple retries for a total of ${totalTimeTaken} milliseconds`)
+
+}
+
+async function assertAgreementStatus (agreementId) {
+  const agreementResponse = await agreementTestHelpers.getAgreement(apiToken, publicApiUrl, agreementId)
+  log.info(`Agreement [${agreementId}] status is ${agreementResponse.status}`)
+
+  if (agreementResponse.status !== 'active') {
+    throw new Error(`Agreement status ${agreementResponse.status} does not equal active`)
+  }
+}
+
+async function wait (seconds) {
+  return new Promise(resolve => setTimeout(resolve, seconds))
+}
+
+async function takeARecurringPaymentForAgreement (agreementId) {
+  log.info(`Taking a recurring payment for [${provider}] and agreement [${agreementId}]`)
+  const createPaymentRequest = smokeTestHelpers.getCreateRecurringPaymentPayload(provider, agreementId)
+  const createPaymentResponse = await smokeTestHelpers.createPayment(apiToken, publicApiUrl, createPaymentRequest)
+
+  await assertPaymentStatus(createPaymentResponse.payment_id)
+}
+
+exports.handler = async () => {
+  secret = await smokeTestHelpers.getSecret(`${ENVIRONMENT}/smoke_test`)
+  apiToken = secret.CARD_STRIPE_API_TOKEN
+  publicApiUrl = secret.PUBLIC_API_URL
+
+  const createAgreementResponse = await createAgreement(provider)
+  const payment = await setupPaymentForAgreement(createAgreementResponse.agreement_id)
+
+  if (WEBHOOKS_ENABLED === 'true') {
+    await smokeTestHelpers.validateWebhookReceived(ENVIRONMENT, payment.payment_id)
+  }
+
+  await assertAgreementStatus(createAgreementResponse.agreement_id)
+
+  await takeARecurringPaymentForAgreement(createAgreementResponse.agreement_id)
+}

--- a/run-local/index.js
+++ b/run-local/index.js
@@ -21,6 +21,7 @@ const TESTS = {
   'make-card-payment-sandbox-without-3ds': proxyquire('../make-card-payment-sandbox-without-3ds', stubs),
   'make-card-payment-stripe-with-3ds2': proxyquire('../make-card-payment-stripe-with-3ds2', stubs),
   'make-card-payment-stripe-without-3ds': proxyquire('../make-card-payment-stripe-without-3ds', stubs),
+  'make-recurring-card-payment-stripe': proxyquire('../make-recurring-card-payment-stripe', stubs),
   'make-card-payment-worldpay-with-3ds': proxyquire('../make-card-payment-worldpay-with-3ds', stubs),
   'make-card-payment-worldpay-with-3ds2': proxyquire('../make-card-payment-worldpay-with-3ds2', stubs),
   'make-card-payment-worldpay-with-3ds2-exemp': proxyquire('../make-card-payment-worldpay-with-3ds2-exemption-engine', stubs),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = [
   singleModule('make-card-payment-worldpay-with-3ds2'),
   singleModule('make-card-payment-worldpay-with-3ds2-exemption-engine'),
   singleModule('make-card-payment-worldpay-without-3ds'),
+  singleModule('make-recurring-card-payment-stripe'),
   singleModule('notifications-sandbox'),
   singleModule('use-payment-link-for-sandbox')
 ]


### PR DESCRIPTION
## WHAT
- Added a new smoke test for Stripe recurring card payments which
   - creates agreement
   - sets up the agreement by taking a payment
   - takes a recurring payment

- Test works for all environments

**Test**
<details>
<summary>aws-vault exec deploy -- node run-local/index.js --test make-recurring-card-payment-stripe --env test --headless</summary>

```
Running make-recurring-card-payment-stripe
Webhooks steps are disabled, pass --webhooks to enable them
Creating agreement for [stripe]
Created agreement [goui3gd865e23tq9nhce4njb6i]
Setting up a payment for [stripe] and agreement [goui3gd865e23tq9nhce4njb6i]
Created payment [tr3cahhifen454roqvk7fhu1tv] for agreement [goui3gd865e23tq9nhce4njb6i]
Going to get page https://card.pymnt.uk/secure/9a2144a4-18d6-4669-a4c1-58e423b0997b
Finished setting up payment [tr3cahhifen454roqvk7fhu1tv] for agreement [goui3gd865e23tq9nhce4njb6i]
Payment [tr3cahhifen454roqvk7fhu1tv] status is success
Agreement [goui3gd865e23tq9nhce4njb6i] status is active
Taking a recurring payment for [stripe] and agreement [goui3gd865e23tq9nhce4njb6i]
Payment [amqsoj1fiqhcdpdvi2e5fmvdhb] status is started
Payment [amqsoj1fiqhcdpdvi2e5fmvdhb] status is started
Payment [amqsoj1fiqhcdpdvi2e5fmvdhb] status is started
Payment [amqsoj1fiqhcdpdvi2e5fmvdhb] status is success
```
</details>

**staging**

<details>
<summary>aws-vault exec deploy -- node run-local/index.js --test make-recurring-card-payment-stripe --env staging --headless</summary>

```
Running make-recurring-card-payment-stripe
Webhooks steps are disabled, pass --webhooks to enable them
Creating agreement for [stripe]
Created agreement [psqq7vf6gfdga0rdku1mhj3h7s]
Setting up a payment for [stripe] and agreement [psqq7vf6gfdga0rdku1mhj3h7s]
Created payment [lsrq0hgnis0aab217l74h3621m] for agreement [psqq7vf6gfdga0rdku1mhj3h7s]
Going to get page https://card.staging.payments.service.gov.uk/secure/dc241908-b929-46fd-8e67-8a7de03fb3f9
Finished setting up payment [lsrq0hgnis0aab217l74h3621m] for agreement [psqq7vf6gfdga0rdku1mhj3h7s]
Payment [lsrq0hgnis0aab217l74h3621m] status is success
Agreement [psqq7vf6gfdga0rdku1mhj3h7s] status is active
Taking a recurring payment for [stripe] and agreement [psqq7vf6gfdga0rdku1mhj3h7s]
Payment [6hcns1g2n2p993lhgjm4hc0ljl] status is started
Payment [6hcns1g2n2p993lhgjm4hc0ljl] status is started
Payment [6hcns1g2n2p993lhgjm4hc0ljl] status is submitted
Payment [6hcns1g2n2p993lhgjm4hc0ljl] status is success
```
</details>

**production** (with webhooks)

<details>
<summary>aws-vault exec deploy -- node run-local/index.js --test make-recurring-card-payment-stripe --env production --headless --webhooks</summary>

```
Running make-recurring-card-payment-stripe
Webhooks steps are enabled
Creating agreement for [stripe]
Created agreement [12qc2dampcaqeb992htjb08i2j]
Setting up a payment for [stripe] and agreement [12qc2dampcaqeb992htjb08i2j]
Created payment [ln6k2fmt1c577mbj632jogq424] for agreement [12qc2dampcaqeb992htjb08i2j]
Going to get page https://card.payments.service.gov.uk/secure/14213b4a-927f-48da-b9d2-dea34b9bbe92
Finished setting up payment [ln6k2fmt1c577mbj632jogq424] for agreement [12qc2dampcaqeb992htjb08i2j]
Payment [ln6k2fmt1c577mbj632jogq424] status is success
Waiting 100ms
Looking for key: webhooks/production-2/ln6k2fmt1c577mbj632jogq424
Found:  {
  resourceId: 'ln6k2fmt1c577mbj632jogq424',
  eventType: 'card_payment_succeeded'
}
Agreement [12qc2dampcaqeb992htjb08i2j] status is active
Taking a recurring payment for [stripe] and agreement [12qc2dampcaqeb992htjb08i2j]
Payment [pb7lj12vmnvrb2q4sq9jcui366] status is started
Payment [pb7lj12vmnvrb2q4sq9jcui366] status is started
Payment [pb7lj12vmnvrb2q4sq9jcui366] status is started
Payment [pb7lj12vmnvrb2q4sq9jcui366] status is success
```
</details>
