### PR TITLE
PP-10496 Increase total payment retry time to 10 seconds

### DIFF
--- a/make-recurring-card-payment-stripe/index.js
+++ b/make-recurring-card-payment-stripe/index.js
@@ -39,8 +39,8 @@ async function setupPaymentForAgreement (agreementId) {
 async function assertPaymentStatus (paymentId) {
   let totalTimeTaken = 0
 
-  // query payment status every one second until it is processed asynchronously in connector for a maximum of 6 seconds
-  for (const retryDelay of new Array(6).fill(1000)) {
+  // query payment status every one second until it is processed asynchronously in connector for a maximum of 10 seconds
+  for (const retryDelay of new Array(10).fill(1000)) {
     await wait(retryDelay)
     totalTimeTaken += retryDelay
 


### PR DESCRIPTION
## What?
- Increase the total time to query for the payment status to 10 seconds as it is taking longer than 6 seconds sometimes for recurring payments to be completed asynchronously. 
     - This is because we have a few seconds of delay before the recurring payment is processed from the task queue and Stripe is taking longer to respond to authorisation requests.

`POST to https://api.stripe.com/v1/payment_intents ended - total time 6790ms`
