### PR TITLE
PP-11029 Smoke test for Sandbox recurring card payment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ in the resource tags, however here's a quick reference guide:
 | Scenario                                       | Environment | Canary name           |
 |------------------------------------------------|-------------|-----------------------|
 | make-card-payment-sandbox-without-3ds          | test        | card_sandbox_test     |
+| make-recurring-card-payment-sandbox            | test        | rec_card_sandbox_test |
 | make-card-payment-stripe-with-3ds2             | test        | card_stripe_3ds_test  |
 | make-card-payment-stripe-without-3ds           | test        | card_stripe_test      |
 | make-card-payment-worldpay-with-3ds            | test        | card_wpay_3ds_test    |
@@ -28,6 +29,7 @@ in the resource tags, however here's a quick reference guide:
 | cancel-card-payment-sandbox-without-3ds        | test        | cancel_sandbox_test   |
 | use-payment-link-for-sandbox                   | test        | pymntlnk_sandbox_test |
 | make-card-payment-sandbox-without-3ds          | staging     | card_sandbox_stag     |
+| make-recurring-card-payment-sandbox            | staging     | rec_card_sandbox_stag |
 | make-card-payment-stripe-with-3ds2             | staging     | card_stripe_3ds_stag  |
 | make-card-payment-stripe-without-3ds           | staging     | card_stripe_stag      |
 | make-card-payment-worldpay-with-3ds            | staging     | card_wpay_3ds_stag    |
@@ -39,6 +41,7 @@ in the resource tags, however here's a quick reference guide:
 | cancel-card-payment-sandbox-without-3ds        | staging     | cancel_sandbox_stag   |
 | use-payment-link-for-sandbox                   | staging     | pymntlnk_sandbox_stag |
 | make-card-payment-sandbox-without-3ds          | production  | card_sandbox_prod     |
+| make-recurring-card-payment-sandbox            | production  | rec_card_sandbox_prod |
 | make-card-payment-stripe-with-3ds2             | production  | card_stripe_3ds_prod  |
 | make-card-payment-stripe-without-3ds           | production  | card_stripe_prod      |
 | make-card-payment-worldpay-with-3ds            | production  | card_wpay_3ds_prod    |

--- a/helpers/recurring-card-payment-test-helpers.js
+++ b/helpers/recurring-card-payment-test-helpers.js
@@ -1,0 +1,73 @@
+const log = require('SyntheticsLogger')
+const smokeTestHelpers = require('./smoke-test-helpers')
+const agreementTestHelpers = require('./agreement-test-helpers')
+
+async function setupPaymentForAgreement (publicApiUrl, apiToken, provider, agreementId, providerCard, emailAddress) {
+  log.info(`Setting up a payment for [${provider}] and agreement [${agreementId}]`)
+  let createPaymentRequest = smokeTestHelpers.createPaymentRequest(provider, 'non_3ds', agreementId)
+  let createPaymentResponse = await smokeTestHelpers.createPayment(apiToken, publicApiUrl, createPaymentRequest)
+  log.info(`Created payment [${createPaymentResponse.payment_id}] for agreement [${agreementId}]`)
+
+  await smokeTestHelpers.enterCardDetailsAndConfirm(createPaymentResponse._links.next_url.href, providerCard, emailAddress)
+  log.info(`Finished setting up payment [${createPaymentResponse.payment_id}] for agreement [${agreementId}]`)
+
+  return assertPaymentStatus(publicApiUrl, apiToken, createPaymentResponse.payment_id)
+}
+
+async function takeARecurringPaymentForAgreement (publicApiUrl, apiToken, provider, agreementId) {
+  log.info(`Taking a recurring payment for [${provider}] and agreement [${agreementId}]`)
+  const createPaymentRequest = smokeTestHelpers.getCreateRecurringPaymentPayload(provider, agreementId)
+  const createPaymentResponse = await smokeTestHelpers.createPayment(apiToken, publicApiUrl, createPaymentRequest)
+
+  await assertPaymentStatus(publicApiUrl, apiToken, createPaymentResponse.payment_id)
+}
+
+async function assertPaymentStatus (publicApiUrl, apiToken, paymentId) {
+  let totalTimeTaken = 0
+
+  // query payment status every one second until it is processed asynchronously in connector for a maximum of 6 seconds
+  for (const retryDelay of new Array(6).fill(1000)) {
+    await wait(retryDelay)
+    totalTimeTaken += retryDelay
+
+    const payment = await smokeTestHelpers.getPayment(apiToken, publicApiUrl, paymentId)
+    const paymentStatus = payment.state.status
+    log.info(`Payment [${paymentId}] status is ${paymentStatus}`)
+
+    if (paymentStatus === 'success') {
+      return payment
+    }
+  }
+
+  throw new Error(`Payment [${paymentId}] status does not equal to success after multiple retries for a total of ${totalTimeTaken} milliseconds`)
+
+}
+
+async function assertAgreementStatus (publicApiUrl, apiToken, agreementId) {
+  const agreementResponse = await agreementTestHelpers.getAgreement(apiToken, publicApiUrl, agreementId)
+  log.info(`Agreement [${agreementId}] status is ${agreementResponse.status}`)
+
+  if (agreementResponse.status !== 'active') {
+    throw new Error(`Agreement status ${agreementResponse.status} does not equal active`)
+  }
+}
+
+async function createAgreement (publicApiUrl, apiToken, provider) {
+  log.info(`Creating agreement for [${provider}]`)
+  const createAgreementPayload = agreementTestHelpers.getCreateAgreementPayload(provider)
+  const createAgreementResponse = await agreementTestHelpers.createAgreement(apiToken, publicApiUrl, createAgreementPayload)
+  log.info(`Created agreement [${createAgreementResponse.agreement_id}]`)
+
+  return createAgreementResponse
+}
+
+async function wait (seconds) {
+  return new Promise(resolve => setTimeout(resolve, seconds))
+}
+
+module.exports = {
+  assertAgreementStatus,
+  createAgreement,
+  setupPaymentForAgreement,
+  takeARecurringPaymentForAgreement
+}

--- a/make-recurring-card-payment-sandbox/index.js
+++ b/make-recurring-card-payment-sandbox/index.js
@@ -1,0 +1,46 @@
+const { ENVIRONMENT, WEBHOOKS_ENABLED } = process.env
+
+const synthetics = require('Synthetics')
+const smokeTestHelpers = require('../helpers/smoke-test-helpers')
+const recCardPaymentTestHelpers = require('../helpers/recurring-card-payment-test-helpers')
+
+const sandboxCard = {
+  cardholderName: 'Test User',
+  cardNumber: '4242424242424242',
+  expiryMonth: smokeTestHelpers.expiryMonth,
+  expiryYear: smokeTestHelpers.expiryYear,
+  securityCode: '737'
+}
+const provider = 'sandbox'
+let apiToken, publicApiUrl, secret
+
+exports.handler = async () => {
+  secret = await smokeTestHelpers.getSecret(`${ENVIRONMENT}/smoke_test`)
+  apiToken = secret.CARD_SANDBOX_API_TOKEN
+  publicApiUrl = secret.PUBLIC_API_URL
+  const emailAddress = secret.EMAIL_ADDRESS
+
+  let createAgreementResponse, payment
+
+  await synthetics.executeStep('Create agreement', async function () {
+    createAgreementResponse = await recCardPaymentTestHelpers.createAgreement(publicApiUrl, apiToken, provider)
+  })
+
+  await synthetics.executeStep('Setup payment for the agreement', async function () {
+    payment = await recCardPaymentTestHelpers.setupPaymentForAgreement(publicApiUrl, apiToken, provider,
+      createAgreementResponse.agreement_id, sandboxCard, emailAddress)
+  })
+
+  if (WEBHOOKS_ENABLED === 'true') {
+    await smokeTestHelpers.validateWebhookReceived(ENVIRONMENT, payment.payment_id)
+  }
+
+  await synthetics.executeStep('Validate agreement status', async function () {
+    await recCardPaymentTestHelpers.assertAgreementStatus(publicApiUrl, apiToken, createAgreementResponse.agreement_id)
+  })
+
+  await synthetics.executeStep('Take a recurring payment for the agreement', async function () {
+    await recCardPaymentTestHelpers.takeARecurringPaymentForAgreement(publicApiUrl, apiToken,
+      provider, createAgreementResponse.agreement_id)
+  })
+}

--- a/run-local/index.js
+++ b/run-local/index.js
@@ -8,17 +8,36 @@ const smokeTestHelpersWithStubs = proxyquire(
   { Synthetics: syntheticsStub, SyntheticsLogger: syntheticsLoggerStub }
 )
 
+const recurringCardPaymentTestHelpersWithStubs = proxyquire(
+  '../helpers/recurring-card-payment-test-helpers.js',
+  {
+    Synthetics: syntheticsStub,
+    SyntheticsLogger: syntheticsLoggerStub,
+    './helpers/agreement-test-helpers': require('../helpers/agreement-test-helpers.js'),
+    '../helpers/smoke-test-helpers': smokeTestHelpersWithStubs
+  }
+)
+
 const stubs = {
   SyntheticsLogger: syntheticsLoggerStub,
   Synthetics: syntheticsStub,
   '../helpers/smoke-test-helpers': smokeTestHelpersWithStubs
 }
+
+const recurringCardPaymentStubs = {
+  SyntheticsLogger: syntheticsLoggerStub,
+  Synthetics: syntheticsStub,
+  '../helpers/smoke-test-helpers': smokeTestHelpersWithStubs,
+  '../helpers/recurring-card-payment-test-helpers': recurringCardPaymentTestHelpersWithStubs
+}
+
 const ENVIRONMENTS = ['test', 'staging', 'production']
 process.env.ENVIRONMENT = argv.env
 process.env.WEBHOOKS_ENABLED = argv.webhooks === undefined ? false : argv.webhooks
 
 const TESTS = {
   'make-card-payment-sandbox-without-3ds': proxyquire('../make-card-payment-sandbox-without-3ds', stubs),
+  'make-recurring-card-payment-sandbox': proxyquire('../make-recurring-card-payment-sandbox', recurringCardPaymentStubs),
   'make-card-payment-stripe-with-3ds2': proxyquire('../make-card-payment-stripe-with-3ds2', stubs),
   'make-card-payment-stripe-without-3ds': proxyquire('../make-card-payment-stripe-without-3ds', stubs),
   'make-recurring-card-payment-stripe': proxyquire('../make-recurring-card-payment-stripe', stubs),


### PR DESCRIPTION
## What?
- Added a new smoke test for Stripe recurring card payment which - creates an agreement - sets up the agreement by taking a payment - takes a recurring payment for the agreement
- Added recurring card payment test helpers so these can be used by Stripe/Worldpay smoke tests for recurring payments

- Works for all environments:

**Test**

```
➜   aws-vault exec deploy -- node run-local/index.js --test make-recurring-card-payment-sandbox --env test --headless
Running make-recurring-card-payment-sandbox
Webhooks steps are disabled, pass --webhooks to enable them
Creating agreement for [sandbox]
Created agreement [200hu00lcvg721cn82ji6l7u3q]
Setting up a payment for [sandbox] and agreement [200hu00lcvg721cn82ji6l7u3q]
Created payment [sob2raouqm2vsv2r15bjl0o77v] for agreement [200hu00lcvg721cn82ji6l7u3q]
Going to get page https://card.pymnt.uk/secure/32ae5743-2af4-42f5-9c86-8d9eabc6255b
Finished setting up payment [sob2raouqm2vsv2r15bjl0o77v] for agreement [200hu00lcvg721cn82ji6l7u3q]
Payment [sob2raouqm2vsv2r15bjl0o77v] status is success
Agreement [200hu00lcvg721cn82ji6l7u3q] status is active
Taking a recurring payment for [sandbox] and agreement [200hu00lcvg721cn82ji6l7u3q]
Payment [epef9h21sbqakfcpmrrh55tk3k] status is started
Payment [epef9h21sbqakfcpmrrh55tk3k] status is success
```
**Staging**

```
➜   aws-vault exec deploy -- node run-local/index.js --test make-recurring-card-payment-sandbox --env staging --headless
Running make-recurring-card-payment-sandbox
Webhooks steps are disabled, pass --webhooks to enable them
Creating agreement for [sandbox]
Created agreement [m4b9p48c4rhofhsf2cmaehn3u6]
Setting up a payment for [sandbox] and agreement [m4b9p48c4rhofhsf2cmaehn3u6]
Created payment [lu9iog7q0bjirjj170t7qhoqj8] for agreement [m4b9p48c4rhofhsf2cmaehn3u6]
Going to get page https://card.staging.payments.service.gov.uk/secure/77aa6372-95f1-4307-a7ea-5ffa8eaef8ef
Finished setting up payment [lu9iog7q0bjirjj170t7qhoqj8] for agreement [m4b9p48c4rhofhsf2cmaehn3u6]
Payment [lu9iog7q0bjirjj170t7qhoqj8] status is success
Agreement [m4b9p48c4rhofhsf2cmaehn3u6] status is active
Taking a recurring payment for [sandbox] and agreement [m4b9p48c4rhofhsf2cmaehn3u6]
Payment [mc67b6vuqkh11e6uh74cnk1ijp] status is started
Payment [mc67b6vuqkh11e6uh74cnk1ijp] status is success
```

**Production**

```
➜  aws-vault exec deploy -- node run-local/index.js --test make-recurring-card-payment-sandbox --env production --headless
Running make-recurring-card-payment-sandbox
Webhooks steps are disabled, pass --webhooks to enable them
Creating agreement for [sandbox]
Created agreement [t3hjmi904au911cjautqshj08l]
Setting up a payment for [sandbox] and agreement [t3hjmi904au911cjautqshj08l]
Created payment [vd775cq7gq45j2c3mb9r40mlkq] for agreement [t3hjmi904au911cjautqshj08l]
Going to get page https://card.payments.service.gov.uk/secure/1cab1046-490b-45ef-9d0c-a69f9500a955
Finished setting up payment [vd775cq7gq45j2c3mb9r40mlkq] for agreement [t3hjmi904au911cjautqshj08l]
Payment [vd775cq7gq45j2c3mb9r40mlkq] status is success
Agreement [t3hjmi904au911cjautqshj08l] status is active
Taking a recurring payment for [sandbox] and agreement [t3hjmi904au911cjautqshj08l]
Payment [beh4al3g31rdj8jhfc2s2dm88u] status is started
Payment [beh4al3g31rdj8jhfc2s2dm88u] status is success
```


