### PR TITLE
PP-11029 Refactor Stripe rec card smoke test

### DIFF
--- a/helpers/smoke-test-helpers.js
+++ b/helpers/smoke-test-helpers.js
@@ -38,7 +38,7 @@ function createPaymentRequest (provider, typeOf3ds, agreementId) {
     amount: 100,
     reference: generatePaymentReference(provider, typeOf3ds, paymentMethod),
     description: 'should create payment, enter card details and confirm',
-    return_url: 'https://products.pymnt.uk/successful'
+    return_url: 'https://pymnt.uk'
   }
 
   if (agreementId) {

--- a/make-recurring-card-payment-stripe/index.js
+++ b/make-recurring-card-payment-stripe/index.js
@@ -1,9 +1,8 @@
 const { ENVIRONMENT, WEBHOOKS_ENABLED } = process.env
 
 const synthetics = require('Synthetics')
-const log = require('SyntheticsLogger')
 const smokeTestHelpers = require('../helpers/smoke-test-helpers')
-const agreementTestHelpers = require('../helpers/agreement-test-helpers')
+const recCardPaymentTestHelpers = require('../helpers/recurring-card-payment-test-helpers')
 
 const stripeCard = {
   cardholderName: 'Test User',
@@ -15,81 +14,21 @@ const stripeCard = {
 const provider = 'stripe'
 let apiToken, publicApiUrl, secret
 
-async function createAgreement (provider) {
-  log.info(`Creating agreement for [${provider}]`)
-  const createAgreementPayload = agreementTestHelpers.getCreateAgreementPayload(provider)
-  const createAgreementResponse = await agreementTestHelpers.createAgreement(apiToken, publicApiUrl, createAgreementPayload)
-  log.info(`Created agreement [${createAgreementResponse.agreement_id}]`)
-
-  return createAgreementResponse
-}
-
-async function setupPaymentForAgreement (agreementId) {
-  log.info(`Setting up a payment for [${provider}] and agreement [${agreementId}]`)
-  let createPaymentRequest = smokeTestHelpers.createPaymentRequest(provider, 'non_3ds', agreementId)
-  let createPaymentResponse = await smokeTestHelpers.createPayment(apiToken, publicApiUrl, createPaymentRequest)
-  log.info(`Created payment [${createPaymentResponse.payment_id}] for agreement [${agreementId}]`)
-
-  await smokeTestHelpers.enterCardDetailsAndConfirm(createPaymentResponse._links.next_url.href, stripeCard, secret.EMAIL_ADDRESS)
-  log.info(`Finished setting up payment [${createPaymentResponse.payment_id}] for agreement [${agreementId}]`)
-
-  return assertPaymentStatus(createPaymentResponse.payment_id)
-}
-
-async function assertPaymentStatus (paymentId) {
-  let totalTimeTaken = 0
-
-  // query payment status every one second until it is processed asynchronously in connector for a maximum of 10 seconds
-  for (const retryDelay of new Array(10).fill(1000)) {
-    await wait(retryDelay)
-    totalTimeTaken += retryDelay
-
-    const payment = await smokeTestHelpers.getPayment(apiToken, publicApiUrl, paymentId)
-    const paymentStatus = payment.state.status
-    log.info(`Payment [${paymentId}] status is ${paymentStatus}`)
-
-    if (paymentStatus === 'success') {
-      return payment
-    }
-  }
-
-  throw new Error(`Payment [${paymentId}] status does not equal to success after multiple retries for a total of ${totalTimeTaken} milliseconds`)
-
-}
-
-async function assertAgreementStatus (agreementId) {
-  const agreementResponse = await agreementTestHelpers.getAgreement(apiToken, publicApiUrl, agreementId)
-  log.info(`Agreement [${agreementId}] status is ${agreementResponse.status}`)
-
-  if (agreementResponse.status !== 'active') {
-    throw new Error(`Agreement status ${agreementResponse.status} does not equal active`)
-  }
-}
-
-async function wait (seconds) {
-  return new Promise(resolve => setTimeout(resolve, seconds))
-}
-
-async function takeARecurringPaymentForAgreement (agreementId) {
-  log.info(`Taking a recurring payment for [${provider}] and agreement [${agreementId}]`)
-  const createPaymentRequest = smokeTestHelpers.getCreateRecurringPaymentPayload(provider, agreementId)
-  const createPaymentResponse = await smokeTestHelpers.createPayment(apiToken, publicApiUrl, createPaymentRequest)
-
-  await assertPaymentStatus(createPaymentResponse.payment_id)
-}
-
 exports.handler = async () => {
   secret = await smokeTestHelpers.getSecret(`${ENVIRONMENT}/smoke_test`)
   apiToken = secret.CARD_STRIPE_API_TOKEN
   publicApiUrl = secret.PUBLIC_API_URL
+  const emailAddress = secret.EMAIL_ADDRESS
+
   let createAgreementResponse, payment
 
   await synthetics.executeStep('Create agreement', async function () {
-    createAgreementResponse = await createAgreement(provider)
+    createAgreementResponse = await recCardPaymentTestHelpers.createAgreement(publicApiUrl, apiToken, provider)
   })
 
   await synthetics.executeStep('Setup payment for the agreement', async function () {
-    payment = await setupPaymentForAgreement(createAgreementResponse.agreement_id)
+    payment = await recCardPaymentTestHelpers.setupPaymentForAgreement(publicApiUrl, apiToken, provider,
+      createAgreementResponse.agreement_id, stripeCard, emailAddress)
   })
 
   if (WEBHOOKS_ENABLED === 'true') {
@@ -97,10 +36,11 @@ exports.handler = async () => {
   }
 
   await synthetics.executeStep('Validate agreement status', async function () {
-    await assertAgreementStatus(createAgreementResponse.agreement_id)
+    await recCardPaymentTestHelpers.assertAgreementStatus(publicApiUrl, apiToken, createAgreementResponse.agreement_id)
   })
 
   await synthetics.executeStep('Take a recurring payment for the agreement', async function () {
-    await takeARecurringPaymentForAgreement(createAgreementResponse.agreement_id)
+    await recCardPaymentTestHelpers.takeARecurringPaymentForAgreement(publicApiUrl, apiToken,
+      provider, createAgreementResponse.agreement_id)
   })
 }

--- a/run-local/index.js
+++ b/run-local/index.js
@@ -40,7 +40,7 @@ const TESTS = {
   'make-recurring-card-payment-sandbox': proxyquire('../make-recurring-card-payment-sandbox', recurringCardPaymentStubs),
   'make-card-payment-stripe-with-3ds2': proxyquire('../make-card-payment-stripe-with-3ds2', stubs),
   'make-card-payment-stripe-without-3ds': proxyquire('../make-card-payment-stripe-without-3ds', stubs),
-  'make-recurring-card-payment-stripe': proxyquire('../make-recurring-card-payment-stripe', stubs),
+  'make-recurring-card-payment-stripe': proxyquire('../make-recurring-card-payment-stripe', recurringCardPaymentStubs),
   'make-card-payment-worldpay-with-3ds': proxyquire('../make-card-payment-worldpay-with-3ds', stubs),
   'make-card-payment-worldpay-with-3ds2': proxyquire('../make-card-payment-worldpay-with-3ds2', stubs),
   'make-card-payment-worldpay-with-3ds2-exemp': proxyquire('../make-card-payment-worldpay-with-3ds2-exemption-engine', stubs),


### PR DESCRIPTION
## What?
- Refactored Stripe recurring card smoke test to use helpers
- Also updated return_url for payments as the existing one returns 404

Tested for test env and still works

```
➜ aws-vault exec deploy -- node run-local/index.js --test make-recurring-card-payment-stripe --env test --headless
Running make-recurring-card-payment-stripe
Webhooks steps are disabled, pass --webhooks to enable them
Creating agreement for [stripe]
Created agreement [h4hvmff0fl8rcs1lfj1g9oc5vg]
Setting up a payment for [stripe] and agreement [h4hvmff0fl8rcs1lfj1g9oc5vg]
Created payment [v4kcadtmrjvrsu0o2afb9j1n09] for agreement [h4hvmff0fl8rcs1lfj1g9oc5vg]
Going to get page https://card.pymnt.uk/secure/2f46b830-6fc9-4f8e-8ca0-5e69f321e118
Finished setting up payment [v4kcadtmrjvrsu0o2afb9j1n09] for agreement [h4hvmff0fl8rcs1lfj1g9oc5vg]
Payment [v4kcadtmrjvrsu0o2afb9j1n09] status is success
Agreement [h4hvmff0fl8rcs1lfj1g9oc5vg] status is active
Taking a recurring payment for [stripe] and agreement [h4hvmff0fl8rcs1lfj1g9oc5vg]
Payment [nhlvj3atek84tedqrohramkguj] status is started
Payment [nhlvj3atek84tedqrohramkguj] status is started
Payment [nhlvj3atek84tedqrohramkguj] status is started
Payment [nhlvj3atek84tedqrohramkguj] status is success
```

