### PR TITLE
PP-10970: Example of Dependabot config for security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay
@@ -15,7 +15,7 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay


### PR DESCRIPTION
See [Github documentation for details](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates). 

This config will:
- only open PRs for security updates for both `npm` and `github-actions` ecosystems.