### PR TITLE
PP-10501 Add Worldpay recurring card payment smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ in the resource tags, however here's a quick reference guide:
 | make-card-payment-worldpay-with-3ds2           | test        | card_wpay_3ds2_test   |
 | make-card-payment-worldpay-with-3ds2-exemption | test        | card_wpay_3ds2ex_test |
 | make-card-payment-worldpay-without-3ds         | test        | card_wpay_test        |
+| make-recurring-card-payment-worldpay           | test        | reccard_worldpay_test |
 | make-recurring-card-payment-stripe             | test        | rec_card_stripe_test  |
 | notifications-sandbox                          | test        | notifications_test    |
 | cancel-card-payment-sandbox-without-3ds        | test        | cancel_sandbox_test   |
@@ -36,6 +37,7 @@ in the resource tags, however here's a quick reference guide:
 | make-card-payment-worldpay-with-3ds2           | staging     | card_wpay_3ds2_stag   |
 | make-card-payment-worldpay-with-3ds2-exemption | staging     | card_wpay_3ds2ex_stag |
 | make-card-payment-worldpay-without-3ds         | staging     | card_wpay_stag        |
+| make-recurring-card-payment-worldpay           | staging     | reccard_worldpay_test |
 | make-recurring-card-payment-stripe             | staging     | rec_card_stripe_stag  |
 | notifications-sandbox                          | staging     | notifications_stag    |
 | cancel-card-payment-sandbox-without-3ds        | staging     | cancel_sandbox_stag   |
@@ -48,6 +50,7 @@ in the resource tags, however here's a quick reference guide:
 | make-card-payment-worldpay-with-3ds2           | production  | card_wpay_3ds2_prod   |
 | make-card-payment-worldpay-with-3ds2-exemption | production  | card_wpay_3ds2ex_prod |
 | make-card-payment-worldpay-without-3ds         | production  | card_wpay_prod        |
+| make-recurring-card-payment-worldpay           | production  | reccard_worldpay_test |
 | make-recurring-card-payment-stripe             | production  | rec_card_stripe_prod  |
 | notifications-sandbox                          | production  | notifications_prod    |
 | cancel-card-payment-sandbox-without-3ds        | production  | cancel_sandbox_prod   |

--- a/make-recurring-card-payment-worldpay/index.js
+++ b/make-recurring-card-payment-worldpay/index.js
@@ -1,0 +1,47 @@
+const { ENVIRONMENT, WEBHOOKS_ENABLED } = process.env
+
+const synthetics = require('Synthetics')
+const smokeTestHelpers = require('../helpers/smoke-test-helpers')
+const recCardPaymentTestHelpers = require('../helpers/recurring-card-payment-test-helpers')
+
+const worldpayCard = {
+  cardholderName: 'Test User',
+  cardNumber: '4462030000000000',
+  expiryMonth: smokeTestHelpers.expiryMonth,
+  expiryYear: smokeTestHelpers.expiryYear,
+  securityCode: '737'
+}
+
+const provider = 'worldpay'
+let apiToken, publicApiUrl, secret
+
+exports.handler = async () => {
+  secret = await smokeTestHelpers.getSecret(`${ENVIRONMENT}/smoke_test`)
+  apiToken = secret.CARD_WORLDPAY_RECURRING_API_TOKEN
+  publicApiUrl = secret.PUBLIC_API_URL
+  const emailAddress = secret.EMAIL_ADDRESS
+
+  let createAgreementResponse, payment
+
+  await synthetics.executeStep('Create agreement', async function () {
+    createAgreementResponse = await recCardPaymentTestHelpers.createAgreement(publicApiUrl, apiToken, provider)
+  })
+
+  await synthetics.executeStep('Setup payment for the agreement', async function () {
+    payment = await recCardPaymentTestHelpers.setupPaymentForAgreement(publicApiUrl, apiToken, provider,
+      createAgreementResponse.agreement_id, worldpayCard, emailAddress, '3ds2')
+  })
+
+  if (WEBHOOKS_ENABLED === 'true') {
+    await smokeTestHelpers.validateWebhookReceived(ENVIRONMENT, payment.payment_id)
+  }
+
+  await synthetics.executeStep('Validate agreement status', async function () {
+    await recCardPaymentTestHelpers.assertAgreementStatus(publicApiUrl, apiToken, createAgreementResponse.agreement_id)
+  })
+
+  await synthetics.executeStep('Take a recurring payment for the agreement', async function () {
+    await recCardPaymentTestHelpers.takeARecurringPaymentForAgreement(publicApiUrl, apiToken,
+      provider, createAgreementResponse.agreement_id)
+  })
+}

--- a/run-local/index.js
+++ b/run-local/index.js
@@ -44,6 +44,7 @@ const TESTS = {
   'make-card-payment-worldpay-with-3ds': proxyquire('../make-card-payment-worldpay-with-3ds', stubs),
   'make-card-payment-worldpay-with-3ds2': proxyquire('../make-card-payment-worldpay-with-3ds2', stubs),
   'make-card-payment-worldpay-with-3ds2-exemp': proxyquire('../make-card-payment-worldpay-with-3ds2-exemption-engine', stubs),
+  'make-recurring-card-payment-worldpay': proxyquire('../make-recurring-card-payment-worldpay', recurringCardPaymentStubs),
   'make-card-payment-worldpay-without-3ds': proxyquire('../make-card-payment-worldpay-without-3ds', stubs),
   'cancel-card-payment-sandbox-without-3ds': proxyquire('../cancel-card-payment-sandbox-without-3ds', stubs),
   'use-payment-link-for-sandbox': proxyquire('../use-payment-link-for-sandbox', stubs),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,7 @@ module.exports = [
   singleModule('make-card-payment-worldpay-with-3ds2'),
   singleModule('make-card-payment-worldpay-with-3ds2-exemption-engine'),
   singleModule('make-card-payment-worldpay-without-3ds'),
+  singleModule('make-recurring-card-payment-worldpay'),
   singleModule('make-recurring-card-payment-stripe'),
   singleModule('notifications-sandbox'),
   singleModule('use-payment-link-for-sandbox')


### PR DESCRIPTION
## What?
- Added new smoke test for Worldpay recurring card payments

<details>
<summary>aws-vault exec deploy -- node run-local/index.js --test make-recurring-card-payment-worldpay --env test --headless</summary>

```
Running make-recurring-card-payment-worldpay
Webhooks steps are disabled, pass --webhooks to enable them
Creating agreement for [worldpay]
Created agreement [2i1hvtug37jgj3of1v3lqes61o]
Setting up a payment for [worldpay] and agreement [2i1hvtug37jgj3of1v3lqes61o]
Created payment [vks8moc2na363t82ngu8m8s8g0] for agreement [2i1hvtug37jgj3of1v3lqes61o]
Going to get page https://card.pymnt.uk/secure/045a15ec-afa4-46cf-acb0-6951ba52b331
Finished setting up payment [vks8moc2na363t82ngu8m8s8g0] for agreement [2i1hvtug37jgj3of1v3lqes61o]
Payment [vks8moc2na363t82ngu8m8s8g0] status is success
Agreement [2i1hvtug37jgj3of1v3lqes61o] status is active
Taking a recurring payment for [worldpay] and agreement [2i1hvtug37jgj3of1v3lqes61o]
Payment [hmcnt1o45m3o3s373d015qp16j] status is started
Payment [hmcnt1o45m3o3s373d015qp16j] status is started
Payment [hmcnt1o45m3o3s373d015qp16j] status is success
```
</details>

<details>
<summary>aws-vault exec deploy -- node run-local/index.js --test make-recurring-card-payment-worldpay --env staging --headless</summary>

```
Running make-recurring-card-payment-worldpay
Webhooks steps are disabled, pass --webhooks to enable them
Creating agreement for [worldpay]
Created agreement [rpgr29jj3qb20ut8u3glgf7l9f]
Setting up a payment for [worldpay] and agreement [rpgr29jj3qb20ut8u3glgf7l9f]
Created payment [ftq2hljevfd0fob68i9bjdpa1p] for agreement [rpgr29jj3qb20ut8u3glgf7l9f]
Going to get page https://card.staging.payments.service.gov.uk/secure/288cbfb2-2657-47f8-8281-d7d5a2f4ef0c
Finished setting up payment [ftq2hljevfd0fob68i9bjdpa1p] for agreement [rpgr29jj3qb20ut8u3glgf7l9f]
Payment [ftq2hljevfd0fob68i9bjdpa1p] status is success
Agreement [rpgr29jj3qb20ut8u3glgf7l9f] status is active
Taking a recurring payment for [worldpay] and agreement [rpgr29jj3qb20ut8u3glgf7l9f]
Payment [12g24sur1fdvsumauev5sa6um1] status is started
Payment [12g24sur1fdvsumauev5sa6um1] status is started
Payment [12g24sur1fdvsumauev5sa6um1] status is success
```
</details>

<details>
<summary>aws-vault exec deploy -- node run-local/index.js --test make-recurring-card-payment-worldpay --env production --headless</summary>

```
Running make-recurring-card-payment-worldpay
Webhooks steps are disabled, pass --webhooks to enable them
Creating agreement for [worldpay]
Created agreement [1ffr048pv2t2n5l74blo3e9qor]
Setting up a payment for [worldpay] and agreement [1ffr048pv2t2n5l74blo3e9qor]
Created payment [qie11lnjip143klmr3e3ff0s12] for agreement [1ffr048pv2t2n5l74blo3e9qor]
Going to get page https://card.payments.service.gov.uk/secure/240ef046-2fa5-431f-9306-8f9d8b473714
Finished setting up payment [qie11lnjip143klmr3e3ff0s12] for agreement [1ffr048pv2t2n5l74blo3e9qor]
Payment [qie11lnjip143klmr3e3ff0s12] status is success
Agreement [1ffr048pv2t2n5l74blo3e9qor] status is active
Taking a recurring payment for [worldpay] and agreement [1ffr048pv2t2n5l74blo3e9qor]
Payment [qe6eq1gjs168ouqj0ohpv0c1ok] status is started
Payment [qe6eq1gjs168ouqj0ohpv0c1ok] status is started
Payment [qe6eq1gjs168ouqj0ohpv0c1ok] status is success

```
</details>