### PR TITLE
PP-11409: Update git workflow to use nvmrc version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: '14'
+          node-version-file: '.nvmrc'
       - name: Cache NPM Node Modules
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         env:


### PR DESCRIPTION
## What?
I forgot to up the node version used to test and run. Instead of manually specifying it, this change will load it from the nvmrc
