### PR TITLE
PP-11409: No-op to trigger release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,4 @@ The smoke test Canaries can then be updated by a developer using the [Concourse 
 
 ## Responsible Disclosure
 GOV.UK Pay aims to stay secure for everyone. If you are a security researcher and have discovered a security vulnerability in this code, we appreciate your help in disclosing it to us in a responsible manner. We will give appropriate credit to those reporting confirmed issues. Please e-mail gds-team-pay-security@digital.cabinet-office.gov.uk with details of any issue you find, we aim to reply quickly.
+


### PR DESCRIPTION
## What?
The previous release was to a github workflow, which doesn't trigger the release workflow, but we need to do a new release on node18....so this is a no-op which will cause a release