### PR TITLE
BAU Update Stripe 3DS card number

### DIFF
--- a/make-card-payment-stripe-with-3ds2/index.js
+++ b/make-card-payment-stripe-with-3ds2/index.js
@@ -6,7 +6,7 @@ const smokeTestHelpers = require('../helpers/smoke-test-helpers')
 
 const stripe3dsCard = {
   cardholderName: 'Test User',
-  cardNumber: '4000000000003063',
+  cardNumber: '4000002500003155',
   expiryMonth: smokeTestHelpers.expiryMonth,
   expiryYear: smokeTestHelpers.expiryYear,
   securityCode: '737'


### PR DESCRIPTION
## WHAT
- Updated Stripe card number to the one we specify in tech docs.

Works locally
`aws-vault exec deploy -- node run-local/index.js --test make-card-payment-stripe-with-3ds2 --env staging --headless`