### PR TITLE
PP-12139: Fix Stripe 3DS smoke test

### DIFF
--- a/make-card-payment-stripe-with-3ds2/index.js
+++ b/make-card-payment-stripe-with-3ds2/index.js
@@ -32,15 +32,10 @@ const enterCardDetailsContinueStripe3dsAndConfirm = async function (nextUrl, car
 
   await synthetics.executeStep('Click submit button on 3DS page', async function () {
     await page.waitForSelector('iframe.iframe-3ds')
-
-    const firstElementHandle = await page.$('iframe.iframe-3ds')
-    const firstIframe = await firstElementHandle.contentFrame()
-    await firstIframe.waitForSelector('iframe.FullscreenFrame')
-
-    const secondElementHandle = await firstIframe.$('iframe.FullscreenFrame')
-    const secondIframe = await secondElementHandle.contentFrame()
-    await secondIframe.waitForSelector('button#test-source-authorize-3ds')
-    await secondIframe.click('button#test-source-authorize-3ds')
+    await page.$('iframe.iframe-3ds')
+    await page.waitForTimeout(5000)
+    const frame = page.frames().find(frame => frame.name() === 'stripe-challenge-frame');
+    await frame.click('#test-source-authorize-3ds')
   })
 
   await navigationPromise


### PR DESCRIPTION
The smoke test was failing with `Waiting for selector iframe.FullscreenFrame`. Upon inspection, the iframe we were interested is in the one with class "ThreeDS2-challenge", not "FullscreenFrame" - see screenshot attached to this PR. However, changing it to the correct name still didn't work. It is suspected that this is because there is an intermediary iframe between iframe-3ds and "ThreeDS2-challenge", so:

```
<iframe class="iframe-3ds">
  <iframe name="__privateStripeFrame0504">
    <iframe class="ThreeDS2-challenge">
    </iframe>
  </iframe>
</iframe>
```

We can't select the second iframe however because the name changes on each test run as it's not controlled by us, and there's no id or class attributes attached to it.

It seems the method presented in this commit works, so let's accept that and move on.

![nested iframes](https://github.com/alphagov/pay-smoke-tests/assets/9698354/a89ddb0e-604a-4200-bb7f-60720d0f78c1)
