### PR TITLE
PP-12687: Add Dependency Review workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -68,3 +68,7 @@ jobs:
         with:
           path: dist
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
+
+  dependency-review:
+    name: Dependency Review scan
+    uses: alphagov/pay-ci/.github/workflows/_run-dependency-review.yml@master


### PR DESCRIPTION
## What?
Adds the new [dependency review workflow](https://github.com/alphagov/pay-ci/pull/1329) to pre-merge checks.