### PR TITLE
PP-12244: Upgrade deprecated Github Actions

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
         with:
           fetch-depth: 0
       - name: Retrieve Build Assets
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a  # v4.1.2
         env:
           cache-name: cache-build-dist
         with:
@@ -51,7 +51,7 @@ jobs:
           echo "ZIPFILENAME=${ZIPFILENAME}" >> $GITHUB_OUTPUT
           
       - name: Upload Archive
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
         with:
           name: ${{ steps.create-zip.outputs.ZIPFILENAME }}
           path: ${{ steps.create-zip.outputs.ZIPFILENAME }}.zip
@@ -59,7 +59,7 @@ jobs:
       - name: Create Release
         if: ${{ github.ref == 'refs/heads/main' }}
         id: create-release
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
       - name: Detect secrets
         uses: alphagov/pay-ci/actions/detect-secrets@master
   lint:
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  #v4.1.0
         with:
           node-version-file: '.nvmrc'
       - name: Cache NPM Node Modules
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a  # v4.1.2
         env:
           cache-name: cache-node-modules
         with:
@@ -40,7 +40,7 @@ jobs:
       - name: Node Lint
         run: npm run lint
       - name: Cache Working Directory
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a  # v4.1.2
         env:
           cache-name: cache-working-dir
         with:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Retrieve Working Directory
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a  # v4.1.2
         env:
           cache-name: cache-working-dir
         with:
@@ -62,7 +62,7 @@ jobs:
       - name: NPM Build
         run: npm run build
       - name: Cache Build Assets
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a  # v4.1.2
         env:
           cache-name: cache-build-dist
         with:


### PR DESCRIPTION
## What?

Upgrades the following Github Actions to run on Node 20, to address deprecation warnings:

`actions/checkout`
`actions/cache`
`actions/upload-artifact`
`actions/github-script`
`actions/setup-node`