### PR TITLE
PP-13405 Fix smoke tests

### DIFF
--- a/helpers/smoke-test-helpers.js
+++ b/helpers/smoke-test-helpers.js
@@ -273,17 +273,12 @@ const getWebhookObjectFromS3 = (environment, resourceId) => {
   return s3.getObject({ Bucket: 'govuk-pay-smoke-tests-results-deploy', Key: path })
 }
 
-const wait = ms => new Promise(resolve => {
-  log.info(`Waiting ${ms}ms`)
-  setTimeout(resolve, ms)
-})
-
 const retrieveWebhookObjectFromS3WithRetries = async (environment, resourceId) => {
   let totalTimeTaken = 0
 
   // We're trying every 100ms for a max of 6 seconds
   for (const retryDelay of new Array(60).fill(100)) {
-    await wait(retryDelay)
+    await setTimeout(retryDelay)
 
     totalTimeTaken += retryDelay
 


### PR DESCRIPTION
## What?
- Uses one version of `setTimeout` method for waiting. `wait()` method is broken (due to changes in https://github.com/alphagov/pay-smoke-tests/pull/238) as the params required are different for `setTimeout` function in `node:timers/promises`

