### PR TITLE
BAU: Upgrade deprecated actions/cache dependency to v4.2.0

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Retrieve Build Assets
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a  # v4.1.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
         env:
           cache-name: cache-build-dist
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - name: Cache NPM Node Modules
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a  # v4.1.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
         env:
           cache-name: cache-node-modules
         with:
@@ -40,7 +40,7 @@ jobs:
       - name: Node Lint
         run: npm run lint
       - name: Cache Working Directory
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a  # v4.1.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
         env:
           cache-name: cache-working-dir
         with:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Retrieve Working Directory
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a  # v4.1.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
         env:
           cache-name: cache-working-dir
         with:
@@ -62,7 +62,7 @@ jobs:
       - name: NPM Build
         run: npm run build
       - name: Cache Build Assets
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a  # v4.1.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
         env:
           cache-name: cache-build-dist
         with:


### PR DESCRIPTION
## What?

Github deprecated the version of `actions/cache` we were using. [We need to upgrade to v4.2.0](https://github.com/actions/cache/releases/tag/v4.2.0).

