### PR TITLE
PP-14368 disable worldpay recurring card payment

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = [
   singleModule('make-card-payment-worldpay-with-3ds2'),
   singleModule('make-card-payment-worldpay-with-3ds2-exemption-engine'),
   singleModule('make-card-payment-worldpay-without-3ds'),
-  singleModule('make-recurring-card-payment-worldpay'),
+  // singleModule('make-recurring-card-payment-worldpay'),
   singleModule('make-recurring-card-payment-stripe'),
   singleModule('notifications-sandbox'),
   singleModule('use-payment-link-for-sandbox')


### PR DESCRIPTION
## What?

Recent changes in connector has broken the smoke test. PP-14366 will fix that. However, we don't have any service taking recurring payments with Worldpay thus we can disable the test. This is so we don't have a `broken window` effect.
