### PR TITLE
PP-14368 disable worldpay recurring card payment part 2

### DIFF
--- a/run-local/index.js
+++ b/run-local/index.js
@@ -43,7 +43,7 @@ const TESTS = {
   'make-recurring-card-payment-stripe': proxyquire('../make-recurring-card-payment-stripe', recurringCardPaymentStubs),
   'make-card-payment-worldpay-with-3ds2': proxyquire('../make-card-payment-worldpay-with-3ds2', stubs),
   'make-card-payment-worldpay-with-3ds2-exemption-engine': proxyquire('../make-card-payment-worldpay-with-3ds2-exemption-engine', stubs),
-  'make-recurring-card-payment-worldpay': proxyquire('../make-recurring-card-payment-worldpay', recurringCardPaymentStubs),
+  // 'make-recurring-card-payment-worldpay': proxyquire('../make-recurring-card-payment-worldpay', recurringCardPaymentStubs),
   'make-card-payment-worldpay-without-3ds': proxyquire('../make-card-payment-worldpay-without-3ds', stubs),
   'cancel-card-payment-sandbox-without-3ds': proxyquire('../cancel-card-payment-sandbox-without-3ds', stubs),
   'use-payment-link-for-sandbox': proxyquire('../use-payment-link-for-sandbox', stubs),


### PR DESCRIPTION
## What?

Recent changes in connector has broken the smoke test. PP-14366 will fix that. However, we don't have any service taking recurring payments with Worldpay thus we can disable the test. This is so we don't have a `broken window` effect.
